### PR TITLE
Fix code climate badge to work off of code climate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # canadarm
 
 [![Build Status](https://api.travis-ci.org/cerner/canadarm.svg)][travis]
-[![Code Climate](http://img.shields.io/codeclimate/github/cerner/canadarm.svg)][codeclimate]
+[![Code Climate](https://codeclimate.com/github/cerner/canadarm/badges/gpa.svg)][codeclimate]
 
 [travis]: https://travis-ci.org/cerner/canadarm
 [codeclimate]: https://codeclimate.com/github/cerner/canadarm


### PR DESCRIPTION
There was an issue with the previous badge not showing all the time. I figure we may as well just pull it from code climate anyway. Shields was used so we could pull more from there, but if it's going to go in and out I have no interest in using it. 

You can check it out here: https://github.com/garrypolley/canadarm/tree/fix-badge

EDIT: Yes I did a terrible thing and did a rebase with a force push. 