### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Canadarm can be installed in the following ways:
 
 * Reference a hosted version provided by [jsdelivr][jsdelivr]:
 
-  `https://cdn.jsdelivr.net/canadarm/1.0.2/canadarm.min.js`
+  `https://cdn.jsdelivr.net/npm/canadarm@1.0.2/build/canadarm.min.js`
 
 # Using canadarm
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Canadarm can be installed in the following ways:
 
   `npm install canadarm`
 
-* Reference a hosted version provided by [jsdelivr][jsdelivr]:
+* Reference a hosted version provided by [jsdelivr](https://www.jsdelivr.com/package/npm/canadarm):
 
   `https://cdn.jsdelivr.net/npm/canadarm@1.0.2/build/canadarm.min.js`
 


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/canadarm.

Feel free to ping me if you have any questions regarding this change.